### PR TITLE
fix work with Azure Devops 2020

### DIFF
--- a/Open AI Code Review/src/pullrequest.ts
+++ b/Open AI Code Review/src/pullrequest.ts
@@ -44,7 +44,7 @@ export class PullRequest {
             }
         }
 
-        let endpoint = `${this._collectionUri}${this._teamProjectId}/_apis/git/repositories/${this._repositoryName}/pullRequests/${this._pullRequestId}/threads?api-version=7.0`
+        let endpoint = `${this._collectionUri}${this._teamProjectId}/_apis/git/repositories/${this._repositoryName}/pullRequests/${this._pullRequestId}/threads?api-version=6.0`
 
         var response = await fetch(endpoint, {
             method: 'POST',


### PR DESCRIPTION
To ensure compatibility with Azure DevOps Server 2020, it is necessary to downgrade the API version.

https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-request-threads/get?view=azure-devops-server-rest-6.0